### PR TITLE
fixed a compile error

### DIFF
--- a/SoftI2CMaster.h
+++ b/SoftI2CMaster.h
@@ -258,7 +258,7 @@ void i2c_wait_scl_high(void)
 }
 
 
-boolean i2c_init(void)
+bool i2c_init(void)
 {
   __asm__ __volatile__ 
     (" cbi      %[SDADDR],%[SDAPIN]     ;release SDA \n\t" 


### PR DESCRIPTION
The error was caused by the use of the C++ bool in the declaration and the arduino boolian in the initialisation.