### PR TITLE
Add I2C_BUFFER_LENGTH

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ definition (in this case, do not define
 <code>I2C_FASTMODE</code>!). This can help to make the communication
 more reliable.
 
+    #define I2C_BUFFER_LENGTH 32
+Some I2C device rx data more then 32 byte, you can use this definition and increase value.
+
 I have measured the maximal bus frequency under different processor
 speeds. The results are displayed in the following
 table. The left value is with <code>I2C_TIMEOUT</code> and

--- a/SoftWire.h
+++ b/SoftWire.h
@@ -24,7 +24,9 @@
 #include <inttypes.h>
 #include "Stream.h"
 
-#define BUFFER_LENGTH 32
+#ifndef I2C_BUFFER_LENGTH
+  #define I2C_BUFFER_LENGTH 32
+#endif
 
 // WIRE_HAS_END means Wire has end()
 #define WIRE_HAS_END 1
@@ -32,7 +34,7 @@
 class SoftWire : public Stream
 {
 private:
-  uint8_t rxBuffer[BUFFER_LENGTH];
+  uint8_t rxBuffer[I2C_BUFFER_LENGTH];
   uint8_t rxBufferIndex;
   uint8_t rxBufferLength;
   uint8_t transmitting;
@@ -124,8 +126,8 @@ public:
       endTransmission(false);
     }
     // clamp to buffer length
-    if(quantity > BUFFER_LENGTH){
-      quantity = BUFFER_LENGTH;
+    if(quantity > I2C_BUFFER_LENGTH){
+      quantity = I2C_BUFFER_LENGTH;
     }
     localerror = !i2c_rep_start((address<<1) | I2C_READ);
     if (error == 0 && localerror) error = 2;


### PR DESCRIPTION
I need more i2c buffer for read PN532 exchanging data.

So I add I2C_BUFFER_LENGTH definition for this.

original issue: https://github.com/arduino/ArduinoCore-sam/issues/19